### PR TITLE
Bump version upto 1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mapgl-gltf",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mapgl-gltf",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "@2gis/mapgl": "1.36.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2gis/mapgl-gltf",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Plugin for the rendering glTF models with MapGL",
   "main": "dist/bundle.js",
   "typings": "dist/types/index.d.ts",


### PR DESCRIPTION
- Version with fix of the link to the docs in readme