### PR TITLE
Light underground floors support

### DIFF
--- a/demo/index.ts
+++ b/demo/index.ts
@@ -35,6 +35,7 @@ async function start() {
         hoverHighlight: {
             intencity: 0.1,
         },
+        groundCoveringColor: 'rgba(233, 232, 220, 0.8)',
     });
 
     (window as any).gltfPlugin = plugin;

--- a/demo/mocks.ts
+++ b/demo/mocks.ts
@@ -8,7 +8,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
         rotateX: 90,
         rotateY: -15.1240072739039,
         scale: 191.637678,
-        linkedIds: ['70030076555821177'],
+        linkedIds: ['70030076555823021'],
         mapOptions: {
             center: [47.24547737708662, 56.134591508663135],
             pitch: 40,
@@ -83,6 +83,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 id: '000034',
                 text: '11',
                 modelUrl: 'zgktechnology1_floor11.glb',
+                isUnderground: true,
                 mapOptions: {
                     center: [47.24556663327373, 56.13456998211929],
                     pitch: 40,
@@ -146,7 +147,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
         rotateX: 90,
         rotateY: -15.1240072739039,
         scale: 191.637678,
-        linkedIds: ['70030076555823021'],
+        linkedIds: ['70030076555821177'],
         mapOptions: {
             center: [47.245008950283065, 56.1344698491912],
             pitch: 45,
@@ -163,6 +164,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 id: 'aaa777',
                 text: '2-15',
                 modelUrl: 'zgktechnology2_floor2.glb',
+                isUnderground: true,
                 mapOptions: {
                     center: [47.24463456947374, 56.134675042798094],
                     pitch: 35,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2gis/mapgl-gltf",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@2gis/mapgl-gltf",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "@2gis/mapgl": "1.37.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2gis/mapgl-gltf",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Plugin for the rendering glTF models with MapGL",
   "main": "dist/bundle.js",
   "typings": "dist/types/index.d.ts",
@@ -8,7 +8,10 @@
     "type": "git",
     "url": "https://github.com/2gis/mapgl-gltf.git"
   },
-  "files": ["dist/libs", "dist/types"],
+  "files": [
+    "dist/libs",
+    "dist/types"
+  ],
   "scripts": {
     "build": "npm run build:bundle && npm run build:typings && npm run build:transpile && npm run build:docs",
     "build:bundle": "webpack --env type=production",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,32 @@
+import type { GeoJsonSourceOptions } from '@2gis/mapgl/types';
+
+export const GROUND_COVERING_SOURCE_DATA: GeoJsonSourceOptions['data'] = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+        type: 'Polygon',
+        coordinates: [
+            [
+                [-180, -85],
+                [180, -85],
+                [180, 85],
+                [-180, 85],
+                [-180, -85],
+            ],
+        ],
+    },
+};
+
+export const GROUND_COVERING_SOURCE_PURPOSE = '__mapglPlugins_mapgl-gltf';
+export const GROUND_COVERING_LAYER = {
+    id: '__mapglPlugins_mapgl-gltf',
+    type: 'polygon',
+    style: {
+        color: ['to-color', ['sourceAttr', 'color']],
+    },
+    filter: [
+        'all',
+        ['match', ['sourceAttr', 'purpose'], [GROUND_COVERING_SOURCE_PURPOSE], true, false],
+        ['to-boolean', ['sourceAttr', 'color']],
+    ],
+};

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -25,4 +25,5 @@ export const defaultOptions: Required<PluginOptions> = {
     floorsControl: {
         position: 'centerLeft',
     },
+    groundCoveringColor: '#00000000',
 };

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -25,5 +25,5 @@ export const defaultOptions: Required<PluginOptions> = {
     floorsControl: {
         position: 'centerLeft',
     },
-    groundCoveringColor: '#00000000',
+    groundCoveringColor: '#F8F8EBCC',
 };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -126,8 +126,8 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
             switch (option) {
                 case 'groundCoveringColor': {
                     this.options.groundCoveringColor = pluginOptions.groundCoveringColor;
-                    this.map.triggerRerender;
                     this.realtyScene?.resetGroundCoveringColor();
+                    break;
                 }
             }
         });

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -18,6 +18,7 @@ import type {
 import type { BuildingOptions } from './types/realtyScene';
 import type { GltfPluginEventTable } from './types/events';
 import { applyOptionalDefaults, disposeObject } from './utils/common';
+import { GROUND_COVERING_LAYER } from './constants';
 
 export class GltfPlugin extends Evented<GltfPluginEventTable> {
     private isThreeJsInitialized = false;
@@ -99,7 +100,7 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
             this.map.setHiddenObjects(hiddenIds);
         }
 
-        this.addThreeJsLayer();
+        this.addLayers();
         this.poiGroups.onMapStyleUpdate();
     };
 
@@ -118,6 +119,18 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
 
     private getLinkedIds() {
         return Array.from(this.linkedIds);
+    }
+
+    public setOptions(pluginOptions: Pick<Required<PluginOptions>, 'groundCoveringColor'>) {
+        Object.keys(pluginOptions).forEach((option) => {
+            switch (option) {
+                case 'groundCoveringColor': {
+                    this.options.groundCoveringColor = pluginOptions.groundCoveringColor;
+                    this.map.triggerRerender;
+                    this.realtyScene?.resetGroundCoveringColor();
+                }
+            }
+        });
     }
 
     /**
@@ -338,6 +351,10 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
             this.viewport.height * window.devicePixelRatio,
         );
 
+        if (this.realtyScene?.isUndergroundFloorShown()) {
+            this.renderer.clearDepth();
+        }
+
         this.renderer.render(this.scene, this.camera);
     }
 
@@ -366,7 +383,8 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
         this.onPluginInit();
     }
 
-    private addThreeJsLayer() {
+    private addLayers() {
+        this.map.addLayer(GROUND_COVERING_LAYER);
         this.map.addLayer({
             id: 'gltf-plugin-style-layer',
             type: 'custom',

--- a/src/realtyScene/realtyScene.ts
+++ b/src/realtyScene/realtyScene.ts
@@ -375,14 +375,15 @@ export class RealtyScene {
             // click to the floor button
             if (ev.floorId !== undefined) {
                 const selectedFloor = model.floors.find((floor) => floor.id === ev.floorId);
-                const activeModelId = this.activeModelId;
-                if (selectedFloor !== undefined && activeModelId !== undefined) {
+                if (selectedFloor !== undefined && this.activeModelId !== undefined) {
                     const selectedFloorModelOption = getFloorModelOptions(selectedFloor, model);
 
                     // In case of underground -> underground and ground -> ground transitions just switch floor's plan
                     if (this.isUndergroundFloorShown() === Boolean(selectedFloor.isUnderground)) {
                         this.plugin.addModel(selectedFloorModelOption).then(() => {
-                            this.plugin.removeModel(activeModelId, true);
+                            if (this.activeModelId !== undefined) {
+                                this.plugin.removeModel(this.activeModelId, true);
+                            }
                             this.addFloorPoi(selectedFloor);
                         });
 
@@ -403,7 +404,7 @@ export class RealtyScene {
                               .filter((scenePart) => scenePart.modelId !== model.modelId)
                               .map((scenePart) => scenePart.modelId);
 
-                    modelsToRemove.push(activeModelId);
+                    modelsToRemove.push(this.activeModelId);
 
                     this.plugin.addModels(modelsToAdd).then(() => {
                         this.plugin.removeModels(modelsToRemove, true);

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -121,6 +121,10 @@ export interface PluginOptions {
      * Settings of the highlighted models
      */
     hoverHighlight?: HightlightOptions;
+    /**
+     * Color for the ground covering when an underground floor's plan is shown.
+     */
+    groundCoveringColor?: string;
 }
 
 /**

--- a/src/types/realtyScene.ts
+++ b/src/types/realtyScene.ts
@@ -50,6 +50,12 @@ export interface BuildingFloorOptions {
      * Map's options to apply after selecting the particular floor
      */
     mapOptions?: MapOptions;
+    /**
+     * Specifies whether a floor's plan is underground.
+     * If value is `true` the map will be covered with a ground geometry
+     * so that only the floor's plan will stay visible.
+     */
+    isUnderground?: boolean;
 }
 
 /**


### PR DESCRIPTION
Что сделано:
1. В опциях этажного плана появился флаг `isUnderground`. Если его значение равно `true`, то при отображении этажа будут скрыты остальные модели, отобразится подложка поверх карты и будет чиститься глубина в буфере, чтобы единственный отображенный подземный этаж не перекрывали объекты из карты.
2. В опциях плагина появилось поле `groundCoveringColor` для цвета подложки из realtyScene.
3. Добавил метод `setOptions` для плагина, чтобы можно было менять цвет подложки налету.
4. Пофиксил баг с непоявлением коробок зданий при удалении сцены недвижки.