### PR TITLE
WebGL 1 для тестов по умолчанию

### DIFF
--- a/test/puppeteer/utils.ts
+++ b/test/puppeteer/utils.ts
@@ -69,6 +69,7 @@ export function initBlankMap(page: PuppeteerPage, options?: mapgl.MapOptions) {
         key: API_KEY,
         styleZoom: MAP_ZOOM,
         center: MAP_CENTER,
+        webglVersion: 1,
         ...options,
     });
 }


### PR DESCRIPTION
Папетир в наших раннерах работает только с WebGL1, так что выставил этот режим в тестах