### PR TITLE
Realty Scene refactoring

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -6,25 +6,12 @@
         <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
         <style>
             html,
-            body {
-                height: 100%;
-                margin: 0;
-                padding: 0;
-            }
-
-            body {
-                padding: 12px;
-            }
-
+            body,
             #container {
-                height: 400px;
-                width: 800px;
-            }
-
-            #stats {
-                background-color: rgba(255, 255, 255, 0.8);
-                max-width: 100%;
-                overflow-y: auto;
+                margin: 0;
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
             }
         </style>
     </head>

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -46,7 +46,6 @@ async function start() {
         .getContainer()
         .addEventListener('click', () => {
             plugin.removeRealtyScene();
-            // plugin.addRealtyScene(REALTY_SCENE, '235034');
             plugin.addRealtyScene(REALTY_SCENE);
         });
 
@@ -64,7 +63,9 @@ async function start() {
         .getContainer()
         .addEventListener('click', () => {
             plugin.removeRealtyScene();
-            plugin.addRealtyScene(REALTY_SCENE_1, 'ds321ba234cb');
+            plugin.addRealtyScene(REALTY_SCENE_1, {
+                buildingId: 'ds321ba234cb',
+            });
         });
 
     new mapglAPI.Control(map, '<button>Remove Scene 1</button>', {

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -34,7 +34,7 @@ async function start() {
         hoverHighlight: {
             intencity: 0.1,
         },
-        groundCoveringColor: 'rgba(233, 232, 220, 0.8)',
+        groundCoveringColor: 'rgba(0, 0, 0, 0.8)',
     });
 
     (window as any).gltfPlugin = plugin;

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -10,7 +10,7 @@ async function start() {
 
     const map = new mapglAPI.Map('container', {
         center: [47.245286302641034, 56.134743473834099],
-        zoom: 17.9,
+        zoom: 18.9,
         key: 'cb20c5bf-34d3-4f0e-9b2b-33e9b8edb57f',
         pitch: 45,
         rotation: 330,
@@ -20,7 +20,7 @@ async function start() {
     (window as any).map = map;
 
     const plugin = new GltfPlugin(map, {
-        modelsLoadStrategy: 'dontWaitAll',
+        modelsLoadStrategy: 'waitAll',
         modelsBaseUrl: 'https://disk.2gis.com/digital-twin/models_s3/realty_ads/zgktechnology/',
         floorsControl: { position: 'centerRight' },
         poiConfig: {
@@ -46,7 +46,8 @@ async function start() {
         .getContainer()
         .addEventListener('click', () => {
             plugin.removeRealtyScene();
-            plugin.addRealtyScene(REALTY_SCENE, { modelId: '03a234cb', floorId: '235034' });
+            // plugin.addRealtyScene(REALTY_SCENE, '235034');
+            plugin.addRealtyScene(REALTY_SCENE);
         });
 
     new mapglAPI.Control(map, '<button>Remove Scene</button>', {
@@ -63,7 +64,7 @@ async function start() {
         .getContainer()
         .addEventListener('click', () => {
             plugin.removeRealtyScene();
-            plugin.addRealtyScene(REALTY_SCENE_1, { modelId: 'ds321ba234cb' });
+            plugin.addRealtyScene(REALTY_SCENE_1, 'ds321ba234cb');
         });
 
     new mapglAPI.Control(map, '<button>Remove Scene 1</button>', {

--- a/demo/mocks.ts
+++ b/demo/mocks.ts
@@ -30,6 +30,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
                     zoom: 20,
                     rotation: -57.5,
                 },
+                isUnderground: true,
                 poiGroups: [
                     {
                         id: '1111',

--- a/demo/mocks.ts
+++ b/demo/mocks.ts
@@ -7,6 +7,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
         modelUrl: 'zgktechnology1.glb',
         rotateZ: -15.1240072739039,
         linkedIds: ['70030076555823021'],
+        interactive: true,
         mapOptions: {
             center: [47.24547737708662, 56.134591508663135],
             pitch: 40,
@@ -14,7 +15,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
             rotation: -41.4,
         },
         popupOptions: {
-            coordinates: [47.24511721603574, 56.13451456056651],
+            coordinates: [47.24498128610925, 56.13451011334241],
             title: 'Корпус 1. 11 этажей',
             description: 'Срок сдачи: IV кв. 2024 г. <br />15 мин. пешком до ст. м. Московская',
         },
@@ -31,7 +32,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 },
                 poiGroups: [
                     {
-                        id: 1111,
+                        id: '1111',
                         type: 'primary',
                         minZoom: 19.5,
                         elevation: 5,
@@ -81,7 +82,6 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 id: '000034',
                 text: '11',
                 modelUrl: 'zgktechnology1_floor11.glb',
-                isUnderground: true,
                 mapOptions: {
                     center: [47.24556663327373, 56.13456998211929],
                     pitch: 40,
@@ -90,7 +90,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 },
                 poiGroups: [
                     {
-                        id: 1111,
+                        id: '1111',
                         type: 'primary',
                         minZoom: 19,
                         elevation: 35,
@@ -142,8 +142,9 @@ export const REALTY_SCENE: BuildingOptions[] = [
         modelId: '1ba234cb',
         coordinates: [47.245286302641034, 56.134743473834099],
         modelUrl: 'zgktechnology2.glb',
-        rotateY: -15.1240072739039,
+        rotateZ: -15.1240072739039,
         linkedIds: ['70030076555821177'],
+        interactive: true,
         mapOptions: {
             center: [47.245008950283065, 56.1344698491912],
             pitch: 45,
@@ -160,7 +161,6 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 id: 'aaa777',
                 text: '2-15',
                 modelUrl: 'zgktechnology2_floor2.glb',
-                isUnderground: true,
                 mapOptions: {
                     center: [47.24463456947374, 56.134675042798094],
                     pitch: 35,
@@ -169,7 +169,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 },
                 poiGroups: [
                     {
-                        id: 1111,
+                        id: '1111',
                         type: 'primary',
                         minZoom: 19.7,
                         elevation: 7,
@@ -255,7 +255,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
                 },
                 poiGroups: [
                     {
-                        id: 1111,
+                        id: '1111',
                         type: 'primary',
                         minZoom: 18.9,
                         elevation: 53,
@@ -335,7 +335,7 @@ export const REALTY_SCENE: BuildingOptions[] = [
         modelId: 'eda234cb',
         coordinates: [47.245286302641034, 56.134743473834099],
         modelUrl: 'zgktechnology_construction.glb',
-        rotateY: -15.1240072739039,
+        rotateZ: -15.1240072739039,
         linkedIds: ['70030076561388553'],
         interactive: false,
     },
@@ -346,8 +346,9 @@ export const REALTY_SCENE_1: BuildingOptions[] = [
         modelId: 'ds321ba234cb',
         coordinates: [47.245286302641034, 56.134743473834099],
         modelUrl: 'zgktechnology2.glb',
-        rotateY: -15.1240072739039,
+        rotateZ: -15.1240072739039,
         linkedIds: ['70030076555823021', '70030076555821177', '70030076555823021'],
+        interactive: true,
         mapOptions: {
             center: [47.245008950283065, 56.1344698491912],
             pitch: 45,
@@ -388,7 +389,7 @@ export const REALTY_SCENE_1: BuildingOptions[] = [
         modelId: '345feda234cb',
         coordinates: [47.245286302641034, 56.134743473834099],
         modelUrl: 'zgktechnology_construction.glb',
-        rotateY: -15.1240072739039,
+        rotateZ: -15.1240072739039,
         linkedIds: ['70030076561388553'],
         interactive: false,
     },

--- a/src/control/index.ts
+++ b/src/control/index.ts
@@ -5,6 +5,7 @@ import icon_building from 'raw-loader!./icon_building.svg';
 import icon_parking from 'raw-loader!./icon_parking.svg';
 import classes from './control.module.css';
 import { Control } from './control';
+import { Id } from '../types';
 
 const content = /* HTML */ `
     <div class="${classes.root}">
@@ -55,29 +56,28 @@ export class GltfFloorControl extends Control {
         this._contentHome.innerHTML = '';
         let currentButton: HTMLElement | undefined;
 
-        floorLevels.forEach((floorLevel) => {
-            const rootContent =
-                floorLevel.modelId === buildingModelId ? this._contentHome : this._content;
+        floorLevels.forEach(({ modelId, text, icon }) => {
+            const rootContent = modelId === buildingModelId ? this._contentHome : this._content;
             const button = document.createElement('button');
-            let buttonContent = floorLevel.text;
-            if (floorLevel.icon) {
-                buttonContent = `<img src = "${floorLevel.icon}">`;
-                if (floorLevel.icon === 'parking') {
+            let buttonContent = text;
+            if (icon) {
+                buttonContent = `<img src = "${icon}">`;
+                if (icon === 'parking') {
                     buttonContent = icon_parking;
                 }
-                if (floorLevel.icon === 'building') {
+                if (icon === 'building') {
                     buttonContent = icon_building;
                 }
             }
             button.className = classes.control;
             button.innerHTML = `<div class="${classes.label}">${buttonContent}</div>`;
-            button.name = floorLevel.modelId;
-            if (this._currentFloorId === floorLevel.modelId) {
+            button.name = modelId;
+            if (this._currentFloorId === modelId) {
                 button.disabled = true;
                 currentButton = button;
             }
 
-            const handler = this._controlHandler(floorLevel);
+            const handler = this._controlHandler(modelId);
             button.addEventListener('click', handler);
 
             this._handlers.set(button, handler);
@@ -120,16 +120,15 @@ export class GltfFloorControl extends Control {
         });
     }
 
-    private _controlHandler = (floorLevel: FloorLevel) => () => {
-        this.switchCurrentFloorLevel(floorLevel);
+    private _controlHandler = (modelId: Id) => () => {
+        this._switchCurrentFloorLevel(modelId);
 
         this.emit('floorchange', {
-            buildingId: floorLevel.buildingModelId,
-            floorId: floorLevel.originalId,
+            modelId,
         });
     };
 
-    private switchCurrentFloorLevel(floorLevel: FloorLevel) {
+    private _switchCurrentFloorLevel(modelId: Id) {
         if (this._currentFloorId === undefined) {
             return;
         }
@@ -142,12 +141,12 @@ export class GltfFloorControl extends Control {
         }
 
         const buttonToEnabled: HTMLButtonElement | null = this._wrap.querySelector(
-            `.${classes.control}[name="${floorLevel.modelId}"]`,
+            `.${classes.control}[name="${modelId}"]`,
         );
         if (buttonToEnabled) {
             buttonToEnabled.disabled = true;
         }
 
-        this._currentFloorId = floorLevel.modelId;
+        this._currentFloorId = modelId;
     }
 }

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -22,7 +22,7 @@ export interface ControlShowOptions {
  * Event that emitted on button presses of the control
  */
 export interface FloorChangeEvent {
-    modelId: Id;
+    modelId: Id; // id модели этажа или здания
 }
 
 export interface ControlEventTable {

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -4,7 +4,9 @@ import { Id } from '../types/plugin';
  * Floor level data
  */
 export interface FloorLevel {
-    floorId?: Id;
+    originalId: Id; // пользовательский id этажа или здания
+    modelId: Id; // id модели этажа или здания
+    buildingModelId: Id; // id модели здания
     text: string;
     icon?: 'parking' | 'building' | string;
 }
@@ -13,8 +15,8 @@ export interface FloorLevel {
  * Options for the method show
  */
 export interface ControlShowOptions {
-    modelId: Id;
-    floorId?: Id;
+    buildingModelId: Id;
+    activeModelId: Id;
     floorLevels?: FloorLevel[];
 }
 
@@ -22,7 +24,7 @@ export interface ControlShowOptions {
  * Event that emitted on button presses of the control
  */
 export interface FloorChangeEvent {
-    modelId: Id;
+    buildingId: Id;
     floorId?: Id;
 }
 
@@ -30,5 +32,5 @@ export interface ControlEventTable {
     /**
      * Emitted when floor's plan was changed
      */
-    floorChange: FloorChangeEvent;
+    floorchange: FloorChangeEvent;
 }

--- a/src/control/types.ts
+++ b/src/control/types.ts
@@ -4,9 +4,7 @@ import { Id } from '../types/plugin';
  * Floor level data
  */
 export interface FloorLevel {
-    originalId: Id; // пользовательский id этажа или здания
     modelId: Id; // id модели этажа или здания
-    buildingModelId: Id; // id модели здания
     text: string;
     icon?: 'parking' | 'building' | string;
 }
@@ -24,8 +22,7 @@ export interface ControlShowOptions {
  * Event that emitted on button presses of the control
  */
 export interface FloorChangeEvent {
-    buildingId: Id;
-    floorId?: Id;
+    modelId: Id;
 }
 
 export interface ControlEventTable {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,7 +1,7 @@
 import type { Map as MapGL } from '@2gis/mapgl/types';
 import type { BuildingOptions } from './types/realtyScene';
 import type { GltfPluginEventTable } from './types/events';
-import type { Id, PluginOptions, ModelOptions } from './types/plugin';
+import type { Id, PluginOptions, ModelOptions, BuildingState } from './types/plugin';
 
 import { applyOptionalDefaults } from './utils/common';
 import { Evented } from './external/evented';
@@ -187,9 +187,9 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
         ids.forEach((id) => this.hideModel(id));
     }
 
-    public async addRealtyScene(scene: BuildingOptions[], activeModelId?: Id) {
+    public async addRealtyScene(scene: BuildingOptions[], state?: BuildingState) {
         this.realtyScene = new RealtyScene(this, this.map, this.options);
-        return this.realtyScene.init(scene, activeModelId);
+        return this.realtyScene.init(scene, state);
     }
 
     // public showRealtyScene() {}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -9,6 +9,7 @@ import { defaultOptions } from './defaultOptions';
 import { concatUrl, isAbsoluteUrl } from './utils/url';
 import { createModelEventData } from './utils/events';
 import { RealtyScene } from './realtyScene/realtyScene';
+import { GROUND_COVERING_LAYER } from './constants';
 
 interface Model {
     instance: any; // GltfModel
@@ -44,8 +45,8 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
      *         modelId: '03a234cb',
      *         coordinates: [82.886554, 54.980988],
      *         modelUrl: 'models/cube_draco.glb',
-     *         rotateX: 90,
-     *         scale: 1000,
+     *         rotateZ: 90,
+     *         scale: 2,
      *     },
      * ]);
      * ```
@@ -58,7 +59,14 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
         this.map = map;
         this.options = applyOptionalDefaults(pluginOptions ?? {}, defaultOptions);
         this.models = new Map();
+
+        map.on('styleload', () => {
+            this.map.addLayer(GROUND_COVERING_LAYER); // мб унести отсюда в RealtyScene, нужно подумать
+            // this.poiGroups.onMapStyleUpdate();
+        });
     }
+
+    // public destroy() {}
 
     public setOptions(pluginOptions: Pick<Required<PluginOptions>, 'groundCoveringColor'>) {
         Object.keys(pluginOptions).forEach((option) => {
@@ -72,8 +80,8 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
         });
     }
 
-    public async addModel(modelToLoad: ModelOptions, showOnLoad = true) {
-        return this.addModels([modelToLoad], showOnLoad ? [modelToLoad.modelId] : []);
+    public async addModel(modelToLoad: ModelOptions, hideOnLoad = false) {
+        return this.addModels([modelToLoad], hideOnLoad ? [] : [modelToLoad.modelId]);
     }
 
     public async addModels(modelsToLoad: ModelOptions[], modelIdsToShow?: Id[]) {
@@ -184,9 +192,9 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
         return this.realtyScene.init(scene, activeModelId);
     }
 
-    public showRealtyScene() {}
+    // public showRealtyScene() {}
 
-    public hideRealtyScene() {}
+    // public hideRealtyScene() {}
 
     public removeRealtyScene() {
         this.realtyScene?.destroy();

--- a/src/realtyScene/realtyScene.ts
+++ b/src/realtyScene/realtyScene.ts
@@ -1,663 +1,574 @@
-// import type { Map as MapGL, AnimationOptions, HtmlMarker, GeoJsonSource } from '@2gis/mapgl/types';
-
-// import { GltfPlugin } from '../plugin';
-// import { defaultOptions } from '../defaultOptions';
-// import { GltfFloorControl } from '../control';
-// import { clone, createCompoundId } from '../utils/common';
-// import classes from './realtyScene.module.css';
-
-// import type { Id, BuildingState, ModelOptions } from '../types/plugin';
-// import type {
-//     BuildingOptions,
-//     MapOptions,
-//     BuildingFloorOptions,
-//     PopupOptions,
-// } from '../types/realtyScene';
-// import type { ControlShowOptions, FloorLevel, FloorChangeEvent } from '../control/types';
-// import type {
-//     GltfPluginModelEvent,
-//     GltfPluginPoiEvent,
-//     PoiGeoJsonProperties,
-// } from '../types/events';
-// import { GROUND_COVERING_LAYER, GROUND_COVERING_SOURCE_DATA, GROUND_COVERING_SOURCE_PURPOSE } from '../constants';
-
-// export class RealtyScene {
-//     private activeBuilding?: BuildingOptions;
-//     private activeModelId?: Id;
-//     private control?: GltfFloorControl;
-//     private activePoiGroupIds: Id[] = [];
-//     private container: HTMLElement;
-//     private buildingFacadeIds: Id[] = [];
-//     // this field is needed when the highlighted
-//     // model is placed under the floors' control
-//     private prevHoveredModelId: Id | null = null;
-//     private popup: HtmlMarker | null = null;
-//     private scene: BuildingOptions[] | null = null;
-//     private groundCoveringSource: GeoJsonSource;
-//     private undergroundFloors = new Set<Id>();
-//     private poiGroups: PoiGroups;
-
-//     constructor(
-//         private plugin: GltfPlugin,
-//         private map: MapGL,
-//         private eventSource: EventSource,
-//         private models: Map<string, THREE.Object3D>,
-//         private options: typeof defaultOptions,
-//     ) {
-//         this.poiGroups = new PoiGroups(this.map, this.options.poiConfig);
-//         this.container = map.getContainer();
-//         this.groundCoveringSource = new mapgl.GeoJsonSource(map, {
-//             maxZoom: 2,
-//             data: GROUND_COVERING_SOURCE_DATA,
-//             attributes: {
-//                 purpose: GROUND_COVERING_SOURCE_PURPOSE,
-//             },
-//         });
-
-//         map.on('styleload', () => {
-//             this.map.addLayer(GROUND_COVERING_LAYER);
-//             this.poiGroups.onMapStyleUpdate();})
-//     }
-
-//     public async add(scene: BuildingOptions[], originalState?: BuildingState) {
-//         // make unique compound identifiers for floor's plans
-//         let state = originalState === undefined ? originalState : clone(originalState);
-//         this.makeUniqueFloorIds(scene);
-//         if (state?.floorId !== undefined) {
-//             state.floorId = createCompoundId(state.modelId, state.floorId);
-//         }
-
-//         // set initial fields
-//         if (state !== undefined) {
-//             this.activeBuilding = scene.find((model) => model.modelId === state?.modelId);
-//             if (this.activeBuilding === undefined) {
-//                 throw new Error(
-//                     `There is no building's model with id ${state.modelId}. ` +
-//                         `Please check options of method addRealtyScene`,
-//                 );
-//             }
-//             this.activeModelId =
-//                 state.floorId !== undefined ? state.floorId : this.activeBuilding.modelId;
-//         }
-
-//         // initialize initial scene
-//         const models: ModelOptions[] = [];
-//         const modelIds: Id[] = [];
-//         this.scene = scene;
-//         scene.forEach((scenePart) => {
-//             this.buildingFacadeIds.push(scenePart.modelId);
-//             const modelOptions = getBuildingModelOptions(scenePart);
-//             const floors = scenePart.floors ?? [];
-//             let hasFloorByDefault = false;
-
-//             for (let floor of floors) {
-//                 if (floor.isUnderground) {
-//                     this.undergroundFloors.add(floor.id);
-//                 }
-
-//                 if (state?.floorId !== undefined && floor.id === state.floorId) {
-//                     // for convenience push original building
-//                     models.push(modelOptions);
-//                     // push modified options for floor
-//                     models.push(getFloorModelOptions(floor, scenePart));
-//                     modelIds.push(floor.id);
-//                     hasFloorByDefault = true;
-//                 }
-//             }
-
-//             if (!hasFloorByDefault) {
-//                 models.push(modelOptions);
-//                 modelIds.push(scenePart.modelId);
-//             }
-
-//             if (this.options.modelsLoadStrategy === 'waitAll') {
-//                 for (let floor of floors) {
-//                     if (floor.id === state?.floorId) {
-//                         continue;
-//                     }
-//                     models.push(getFloorModelOptions(floor, scenePart));
-//                 }
-//             }
-//         });
-
-//         // Leave only the underground floor's plan to be shown
-//         if (state?.floorId !== undefined && this.undergroundFloors.has(state.floorId)) {
-//             modelIds.length = 0;
-//             modelIds.push(state.floorId);
-//         }
-
-//         return this.plugin.addModelsPartially(models, modelIds).then(() => {
-//             // set options after adding models
-//             if (state?.floorId !== undefined) {
-//                 const floors = this.activeBuilding?.floors ?? [];
-//                 const activeFloor = floors.find((floor) => floor.id === state?.floorId);
-//                 this.setMapOptions(activeFloor?.mapOptions);
-//                 this.addFloorPoi(activeFloor);
-//                 if (this.undergroundFloors.has(state.floorId)) {
-//                     this.switchOnGroundCovering();
-//                 }
-//             } else {
-//                 this.setMapOptions(this.activeBuilding?.mapOptions);
-//             }
-
-//             // initialize floors' control
-//             const { position } = this.options.floorsControl;
-//             this.control = new GltfFloorControl(this.map, { position });
-//             if (state !== undefined) {
-//                 const controlOptions = this.createControlOptions(scene, state);
-//                 this.control?.show(controlOptions);
-//                 if (state.floorId) {
-//                     this.eventSource.setCurrentFloorId(state.floorId);
-//                 }
-//             }
-
-//             // bind all events
-//             this.bindRealtySceneEvents();
-//         });
-//     }
-
-//     public resetGroundCoveringColor() {
-//         const attrs = this.groundCoveringSource.getAttributes();
-//         if ('color' in attrs) {
-//             this.groundCoveringSource.setAttributes({
-//                 ...attrs,
-//                 color: this.options.groundCoveringColor,
-//             });
-//         }
-//     }
-
-//     public isUndergroundFloorShown() {
-//         return this.activeModelId !== undefined && this.undergroundFloors.has(this.activeModelId);
-//     }
-
-//     public destroy(preserveCache?: boolean) {
-//         this.unbindRealtySceneEvents();
-
-//         this.plugin.removeModels(
-//             this.scene?.reduce<Id[]>((agg, opts) => {
-//                 agg.push(opts.modelId);
-//                 opts.floors?.forEach((floor) => agg.push(floor.id));
-
-//                 return agg;
-//             }, []) ?? [],
-//             preserveCache,
-//         );
-
-//         this.clearPoiGroups();
-//         this.eventSource.setCurrentFloorId(null);
-
-//         this.groundCoveringSource.destroy();
-//         this.undergroundFloors.clear();
-
-//         this.control?.destroy();
-//         this.control = undefined;
-
-//         this.popup?.destroy();
-//         this.popup = null;
-
-//         this.activeBuilding = undefined;
-//         this.activeModelId = undefined;
-//         this.activePoiGroupIds = [];
-//         this.buildingFacadeIds = [];
-//         this.prevHoveredModelId = null;
-//         this.scene = null;
-//     }
-
-//     private bindRealtySceneEvents() {
-//         this.plugin.on('click', this.onSceneClick);
-//         this.plugin.on('mouseover', this.onSceneMouseOver);
-//         this.plugin.on('mouseout', this.onSceneMouseOut);
-
-//         this.control?.on('floorChange', this.floorChangeHandler);
-//     }
-
-//     private unbindRealtySceneEvents() {
-//         this.plugin.off('click', this.onSceneClick);
-//         this.plugin.off('mouseover', this.onSceneMouseOver);
-//         this.plugin.off('mouseout', this.onSceneMouseOut);
-
-//         this.control?.off('floorChange', this.floorChangeHandler);
-//     }
-
-//     private createControlOptions(scene: BuildingOptions[], buildingState: BuildingState) {
-//         const { modelId, floorId } = buildingState;
-//         const options: ControlShowOptions = {
-//             modelId: modelId,
-//         };
-//         if (floorId !== undefined) {
-//             options.floorId = floorId;
-//         }
-
-//         const buildingData = scene.find((scenePart) => scenePart.modelId === modelId);
-//         if (!buildingData) {
-//             return options;
-//         }
-
-//         if (buildingData.floors !== undefined) {
-//             const floorLevels: FloorLevel[] = [
-//                 {
-//                     icon: 'building',
-//                     text: '',
-//                 },
-//             ];
-//             buildingData.floors.forEach((floor) => {
-//                 floorLevels.push({
-//                     floorId: floor.id,
-//                     text: floor.text,
-//                 });
-//             });
-//             options.floorLevels = floorLevels;
-//         }
-//         return options;
-//     }
-
-//     private setMapOptions(options?: MapOptions) {
-//         if (!options) {
-//             return;
-//         }
-
-//         const animationOptions: AnimationOptions = {
-//             easing: 'easeInSine',
-//             duration: 500,
-//         };
-//         if (options.center) {
-//             this.map.setCenter(options.center, animationOptions);
-//         }
-//         if (options.pitch) {
-//             this.map.setPitch(options.pitch, animationOptions);
-//         }
-//         if (options.rotation) {
-//             this.map.setRotation(options.rotation, animationOptions);
-//         }
-//         if (options.zoom) {
-//             this.map.setZoom(options.zoom, animationOptions);
-//         }
-//     }
-
-//     // checks if the modelId is external facade of the building
-//     private isFacadeBuilding(modelId?: Id): modelId is Id {
-//         if (modelId === undefined) {
-//             return false;
-//         }
-
-//         return this.buildingFacadeIds.includes(modelId);
-//     }
-
-//     private getPopupOptions(modelId: Id): PopupOptions | undefined {
-//         if (this.scene === null) {
-//             return;
-//         }
-//         let building = this.scene.find((building) => building.modelId === modelId);
-//         if (building === undefined) {
-//             return;
-//         }
-//         return building.popupOptions;
-//     }
-
-//     private onSceneMouseOver = (ev: GltfPluginPoiEvent | GltfPluginModelEvent) => {
-//         if (ev.target.type === 'model') {
-//             const id = ev.target.modelId;
-//             if (this.isFacadeBuilding(id)) {
-//                 this.container.style.cursor = 'pointer';
-//                 this.toggleHighlightModel(id);
-//                 let popupOptions = this.getPopupOptions(id);
-//                 if (popupOptions) {
-//                     this.showPopup(popupOptions);
-//                 }
-//             }
-//         }
-//     };
-//     private onSceneMouseOut = (ev: GltfPluginPoiEvent | GltfPluginModelEvent) => {
-//         if (ev.target.type === 'model') {
-//             const id = ev.target.modelId;
-//             if (this.isFacadeBuilding(id)) {
-//                 this.container.style.cursor = '';
-//                 this.hidePopup();
-//                 if (this.prevHoveredModelId !== null) {
-//                     this.toggleHighlightModel(id);
-//                 }
-//             }
-//         }
-//     };
-
-//     private onSceneClick = (ev: GltfPluginPoiEvent | GltfPluginModelEvent) => {
-//         if (this.scene === null) {
-//             return;
-//         }
-
-//         if (ev.target.type === 'model') {
-//             const id = ev.target.modelId;
-//             if (this.isFacadeBuilding(id)) {
-//                 this.buildingClickHandler(this.scene, id);
-//             }
-//         }
-
-//         if (ev.target.type === 'poi') {
-//             this.poiClickHandler(ev.target.data);
-//         }
-//     };
-
-//     private poiClickHandler = (data: PoiGeoJsonProperties) => {
-//         const url: string | undefined = data.userData.url;
-//         if (url !== undefined) {
-//             const a = document.createElement('a');
-//             a.setAttribute('href', url);
-//             a.setAttribute('target', '_blank');
-//             a.click();
-//         }
-//     };
-
-//     private floorChangeHandler = (ev: FloorChangeEvent) => {
-//         const model = this.activeBuilding;
-//         if (model !== undefined && model.floors !== undefined) {
-//             if (this.popup !== null) {
-//                 this.popup.destroy();
-//             }
-
-//             // click to the building button
-//             if (ev.floorId === undefined) {
-//                 if (this.prevHoveredModelId !== null) {
-//                     this.toggleHighlightModel(this.prevHoveredModelId);
-//                 }
-
-//                 this.clearPoiGroups();
-//                 const modelsToAdd: ModelOptions[] = this.isUndergroundFloorShown()
-//                     ? (this.scene ?? []).map((scenePart) => getBuildingModelOptions(scenePart))
-//                     : [getBuildingModelOptions(model)];
-
-//                 this.plugin.addModels(modelsToAdd).then(() => {
-//                     if (this.activeModelId !== undefined) {
-//                         this.plugin.removeModel(this.activeModelId, true);
-//                         if (this.isUndergroundFloorShown()) {
-//                             this.switchOffGroundCovering();
-//                         }
-//                     }
-//                     this.setMapOptions(model?.mapOptions);
-//                     this.activeModelId = model.modelId;
-//                 });
-//             }
-//             // click to the floor button
-//             if (ev.floorId !== undefined) {
-//                 const selectedFloor = model.floors.find((floor) => floor.id === ev.floorId);
-//                 if (selectedFloor !== undefined && this.activeModelId !== undefined) {
-//                     const selectedFloorModelOption = getFloorModelOptions(selectedFloor, model);
-
-//                     // In case of underground -> underground and ground -> ground transitions just switch floor's plan
-//                     if (this.isUndergroundFloorShown() === Boolean(selectedFloor.isUnderground)) {
-//                         this.plugin.addModel(selectedFloorModelOption).then(() => {
-//                             if (this.activeModelId !== undefined) {
-//                                 this.plugin.removeModel(this.activeModelId, true);
-//                             }
-//                             this.addFloorPoi(selectedFloor);
-//                         });
-
-//                         return;
-//                     }
-
-//                     const modelsToAdd: ModelOptions[] = this.isUndergroundFloorShown()
-//                         ? (this.scene ?? [])
-//                               .filter((scenePart) => scenePart.modelId !== model.modelId)
-//                               .map((scenePart) => getBuildingModelOptions(scenePart))
-//                         : [];
-
-//                     modelsToAdd.push(selectedFloorModelOption);
-
-//                     const modelsToRemove = this.isUndergroundFloorShown()
-//                         ? []
-//                         : (this.scene ?? [])
-//                               .filter((scenePart) => scenePart.modelId !== model.modelId)
-//                               .map((scenePart) => scenePart.modelId);
-
-//                     modelsToRemove.push(this.activeModelId);
-
-//                     this.plugin.addModels(modelsToAdd).then(() => {
-//                         this.plugin.removeModels(modelsToRemove, true);
-//                         this.isUndergroundFloorShown()
-//                             ? this.switchOffGroundCovering()
-//                             : this.switchOnGroundCovering();
-//                         this.addFloorPoi(selectedFloor);
-//                     });
-//                 }
-//             }
-//         }
-//     };
-
-//     private buildingClickHandler = (scene: BuildingOptions[], modelId: Id) => {
-//         const selectedBuilding = scene.find((model) => model.modelId === modelId);
-//         if (selectedBuilding === undefined) {
-//             return;
-//         }
-
-//         // don't show the pointer cursor on the model when user
-//         // started to interact with the building
-//         this.container.style.cursor = '';
-
-//         if (this.popup !== null) {
-//             this.popup.destroy();
-//         }
-
-//         // if there is a visible floor plan, then show the external
-//         // facade of the active building before focusing on the new building
-//         if (
-//             this.activeBuilding &&
-//             this.activeModelId &&
-//             this.activeModelId !== this.activeBuilding?.modelId
-//         ) {
-//             // User is able to click on any other buildings as long as ground floor's plan is shown
-//             // because when underground floor's plan is shown other buildings are hidden.
-//             const oldId = this.activeModelId;
-//             this.plugin.addModel(getBuildingModelOptions(this.activeBuilding)).then(() => {
-//                 this.clearPoiGroups();
-//                 this.plugin.removeModel(oldId, true);
-//             });
-//         }
-
-//         // show the highest floor after a click on the building
-//         const floors = selectedBuilding.floors ?? [];
-//         if (floors.length !== 0) {
-//             const floorOptions = floors[floors.length - 1];
-
-//             const modelsToRemove = floorOptions.isUnderground
-//                 ? scene.map((scenePart) => scenePart.modelId)
-//                 : [selectedBuilding.modelId];
-
-//             this.plugin.addModel(getFloorModelOptions(floorOptions, selectedBuilding)).then(() => {
-//                 this.plugin.removeModels(modelsToRemove, true);
-//                 if (floorOptions.isUnderground) {
-//                     this.switchOnGroundCovering();
-//                 }
-//                 this.addFloorPoi(floorOptions);
-//                 this.control?.switchCurrentFloorLevel(selectedBuilding.modelId, floorOptions.id);
-//             });
-//         } else {
-//             this.activeModelId = selectedBuilding.modelId;
-//             this.setMapOptions(selectedBuilding.mapOptions);
-//         }
-
-//         if (
-//             this.activeBuilding === undefined ||
-//             selectedBuilding.modelId !== this.activeBuilding?.modelId
-//         ) {
-//             // initialize control
-//             const { position } = this.options.floorsControl;
-//             this.control?.destroy();
-//             this.control = new GltfFloorControl(this.map, { position });
-//             const state = { modelId: selectedBuilding.modelId };
-//             const controlOptions = this.createControlOptions(scene, state);
-//             this.control?.show(controlOptions);
-//             this.control.on('floorChange', (ev) => {
-//                 this.floorChangeHandler(ev);
-//             });
-//         }
-
-//         this.activeBuilding = selectedBuilding;
-//     };
-
-//     private addFloorPoi(floorOptions?: BuildingFloorOptions) {
-//         if (floorOptions === undefined) {
-//             return;
-//         }
-
-//         this.activeModelId = floorOptions.id;
-
-//         this.setMapOptions(floorOptions?.mapOptions);
-
-//         this.clearPoiGroups();
-
-//         floorOptions.poiGroups?.forEach((poiGroup) => {
-//             if (this.activeBuilding?.modelId) {
-//                 this.plugin.addPoiGroup(poiGroup, {
-//                     modelId: this.activeBuilding?.modelId,
-//                     floorId: floorOptions.id,
-//                 });
-//                 this.activePoiGroupIds.push(poiGroup.id);
-//             }
-//         });
-//     }
-
-//     private clearPoiGroups() {
-//         this.activePoiGroupIds.forEach((id) => {
-//             this.plugin.removePoiGroup(id);
-//         });
-
-//         this.activePoiGroupIds = [];
-//     }
-
-//     /**
-//      * Add the group of poi to the map
-//      *
-//      * @param options Options of the group of poi to add to the map
-//      * @param state State of the active building to connect with added the group of poi
-//      */
-//     public async addPoiGroup(options: PoiGroupOptions, state?: BuildingState) {
-//         this.poiGroups.add(options, state);
-//     }
-
-//     /**
-//      * Remove the group of poi from the map
-//      *
-//      * @param id Identifier of the group of poi to remove
-//      */
-//     public removePoiGroup(id: Id) {
-//         this.poiGroups.remove(id);
-//     }
-
-//     // TODO: Don't mutate scene data.
-//     private makeUniqueFloorIds(scene: BuildingOptions[]) {
-//         for (let scenePart of scene) {
-//             const floors = scenePart.floors ?? [];
-//             for (let floor of floors) {
-//                 if (!floor.id.toString().startsWith(scenePart.modelId.toString())) {
-//                     floor.id = createCompoundId(scenePart.modelId, floor.id);
-//                 }
-//             }
-//         }
-//     }
-
-//     public toggleHighlightModel(modelId: Id) {
-//         // skip toggle if user is using default emissiveIntensity
-//         // that means that model won't be hovered
-//         const { intencity } = this.options.hoverHighlight;
-//         if (intencity === 0) {
-//             return;
-//         }
-
-//         const model = this.models.get(String(modelId));
-
-//         if (model === undefined) {
-//             return;
-//         }
-
-//         let shouldUnsetFlag = false;
-//         model.traverse((obj) => {
-//             if (obj instanceof THREE.Mesh) {
-//                 if (modelId === this.prevHoveredModelId) {
-//                     obj.material.emissiveIntensity = 0.0;
-//                     shouldUnsetFlag = true;
-//                 } else {
-//                     obj.material.emissiveIntensity = intencity;
-//                 }
-//             }
-//         });
-
-//         this.prevHoveredModelId = shouldUnsetFlag ? null : modelId;
-//         this.map.triggerRerender();
-//     }
-
-//     private showPopup(options: PopupOptions) {
-//         this.popup = new mapgl.HtmlMarker(this.map, {
-//             coordinates: options.coordinates,
-//             html: this.getPopupHtml(options),
-//         });
-//     }
-
-//     private hidePopup() {
-//         if (this.popup !== null) {
-//             this.popup.destroy();
-//             this.popup = null;
-//         }
-//     }
-
-//     private getPopupHtml(data: PopupOptions) {
-//         if (data.description === undefined) {
-//             return `<div class="${classes.popup}">
-//                 <h2>${data.title}</h2>
-//             </div>`;
-//         }
-
-//         return `<div class="${classes.popup}">
-//             <h2>${data.title}</h2>
-//             <p>${data.description}</p>
-//         </div>`;
-//     }
-
-//     private switchOffGroundCovering() {
-//         const attrs = { ...this.groundCoveringSource.getAttributes() };
-//         delete attrs['color'];
-//         this.groundCoveringSource.setAttributes(attrs);
-//     }
-
-//     private switchOnGroundCovering() {
-//         this.groundCoveringSource.setAttributes({
-//             ...this.groundCoveringSource.getAttributes(),
-//             color: this.options.groundCoveringColor,
-//         });
-//     }
-// }
-
-// function getBuildingModelOptions(building: BuildingOptions): ModelOptions {
-//     return {
-//         modelId: building.modelId,
-//         coordinates: building.coordinates,
-//         modelUrl: building.modelUrl,
-//         rotateX: building.rotateX,
-//         rotateY: building.rotateY,
-//         rotateZ: building.rotateZ,
-//         offsetX: building.offsetX,
-//         offsetY: building.offsetY,
-//         offsetZ: building.offsetZ,
-//         scale: building.scale,
-//         linkedIds: building.linkedIds,
-//         interactive: building.interactive,
-//     };
-// }
-
-// function getFloorModelOptions(
-//     floor: BuildingFloorOptions,
-//     building: BuildingOptions,
-// ): ModelOptions {
-//     return {
-//         modelId: floor.id,
-//         coordinates: building.coordinates,
-//         modelUrl: floor.modelUrl,
-//         rotateX: building.rotateX,
-//         rotateY: building.rotateY,
-//         rotateZ: building.rotateZ,
-//         offsetX: building.offsetX,
-//         offsetY: building.offsetY,
-//         offsetZ: building.offsetZ,
-//         scale: building.scale,
-//         linkedIds: building.linkedIds,
-//         interactive: building.interactive,
-//     };
-// }
+import type { Map as MapGL, AnimationOptions, HtmlMarker, GeoJsonSource } from '@2gis/mapgl/types';
+
+import { GltfPlugin } from '../plugin';
+import { GltfFloorControl } from '../control';
+import classes from './realtyScene.module.css';
+
+import type { Id, ModelOptions, PluginOptions } from '../types/plugin';
+import type {
+    BuildingOptions,
+    MapOptions,
+    BuildingFloorOptions,
+    PopupOptions,
+} from '../types/realtyScene';
+import type { FloorLevel, FloorChangeEvent } from '../control/types';
+import type {
+    GltfPluginModelEvent,
+    GltfPluginPoiEvent,
+    PoiGeoJsonProperties,
+} from '../types/events';
+import {
+    GROUND_COVERING_LAYER,
+    GROUND_COVERING_SOURCE_DATA,
+    GROUND_COVERING_SOURCE_PURPOSE,
+} from '../constants';
+
+interface RealtySceneState {
+    activeModelId?: Id;
+
+    // id здания мапится на опции здания или опции этажа этого здания
+    buildingVisibility: Map<Id, ModelOptions | undefined>;
+}
+
+type BuildingOptionsInternal = Omit<BuildingOptions, 'floors'> & {
+    floors: FloorLevel[];
+};
+type BuildingFloorOptionsInternal = BuildingFloorOptions & {
+    buildingOptions: ModelOptions;
+};
+
+export class RealtyScene {
+    private buildings = new Map<Id, BuildingOptionsInternal>();
+    private floors = new Map<Id, BuildingFloorOptionsInternal>();
+    private undergroundFloors = new Set<Id>();
+    private state: RealtySceneState = {
+        activeModelId: undefined,
+        buildingVisibility: new Map(),
+    };
+
+    private groundCoveringSource: GeoJsonSource;
+    private control: GltfFloorControl;
+    private popup?: HtmlMarker;
+
+    // private poiGroups: PoiGroups;
+
+    constructor(
+        private plugin: GltfPlugin,
+        private map: MapGL,
+        private options: Required<PluginOptions>,
+    ) {
+        const { position } = this.options.floorsControl;
+        this.control = new GltfFloorControl(this.map, { position });
+        // this.poiGroups = new PoiGroups(this.map, this.options.poiConfig);
+        this.groundCoveringSource = new mapgl.GeoJsonSource(map, {
+            maxZoom: 2,
+            data: GROUND_COVERING_SOURCE_DATA,
+            attributes: {
+                purpose: GROUND_COVERING_SOURCE_PURPOSE,
+            },
+        });
+
+        map.on('styleload', () => {
+            this.map.addLayer(GROUND_COVERING_LAYER);
+            // this.poiGroups.onMapStyleUpdate();
+        });
+    }
+
+    private getBuildingModelId(id: Id | undefined) {
+        if (id === undefined) {
+            return;
+        }
+
+        if (this.buildings.has(id)) {
+            return id;
+        } else {
+            const floor = this.floors.get(id);
+            if (floor) {
+                return floor.buildingOptions.modelId;
+            }
+        }
+    }
+
+    private setState(newState: RealtySceneState) {
+        const prevState = this.state;
+
+        this.buildings.forEach((_, buildingId) => {
+            const prevModelOptions = prevState.buildingVisibility.get(buildingId);
+            const newModelOptions = newState.buildingVisibility.get(buildingId);
+            if (prevModelOptions) {
+                this.plugin.hideModel(prevModelOptions.modelId);
+            }
+
+            if (newModelOptions) {
+                this.plugin.isModelAdded(newModelOptions.modelId)
+                    ? this.plugin.showModel(newModelOptions.modelId)
+                    : this.plugin.addModel(newModelOptions);
+            }
+        });
+
+        if (prevState.activeModelId !== newState.activeModelId) {
+            if (
+                prevState.activeModelId !== undefined &&
+                this.undergroundFloors.has(prevState.activeModelId)
+            ) {
+                this.switchOffGroundCovering();
+            }
+
+            if (newState.activeModelId !== undefined) {
+                const options =
+                    this.buildings.get(newState.activeModelId) ??
+                    this.floors.get(newState.activeModelId);
+                if (options) {
+                    this.setMapOptions(options.mapOptions);
+                    // this.addFloorPoi(activeFloor);
+                }
+
+                if (this.undergroundFloors.has(newState.activeModelId)) {
+                    this.switchOnGroundCovering();
+                }
+            }
+        }
+
+        const prevBuildingModelId = this.getBuildingModelId(prevState.activeModelId);
+        const newBuildingModelId = this.getBuildingModelId(newState.activeModelId);
+
+        if (prevBuildingModelId !== newBuildingModelId) {
+            if (newBuildingModelId !== undefined && newState.activeModelId !== undefined) {
+                const buildingOptions = this.buildings.get(newBuildingModelId);
+                if (buildingOptions) {
+                    this.control.show({
+                        buildingModelId: buildingOptions.modelId,
+                        activeModelId: newState.activeModelId,
+                        floorLevels: [
+                            {
+                                modelId: buildingOptions.modelId,
+                                originalId: buildingOptions.modelId,
+                                buildingModelId: buildingOptions.modelId,
+                                icon: 'building',
+                                text: '',
+                            },
+                            ...buildingOptions.floors,
+                        ],
+                    });
+                }
+            }
+        }
+
+        this.state = newState;
+    }
+
+    public async init(scene: BuildingOptions[], activeModelId?: string) {
+        scene.forEach((building) => {
+            const { floors, ...buildingPart } = building;
+            const internalBuilding: BuildingOptionsInternal = {
+                ...buildingPart,
+                floors: [],
+            };
+            const buildingOptions = getBuildingModelOptions(internalBuilding);
+
+            (floors ?? []).forEach((floor) => {
+                const floorModelId = getFloorModelId(building.modelId, floor.id);
+                internalBuilding.floors.push({
+                    modelId: floorModelId,
+                    originalId: floor.id,
+                    buildingModelId: building.modelId,
+                    text: floor.text,
+                    icon: floor.icon,
+                });
+
+                // Подменяем id активного этажа на внутренний формат buildingId_floorId
+                if (activeModelId === floor.id) {
+                    activeModelId = floorModelId;
+                }
+
+                this.floors.set(floorModelId, {
+                    ...floor,
+                    buildingOptions: buildingOptions,
+                });
+
+                if (floor.isUnderground) {
+                    this.undergroundFloors.add(floorModelId);
+                }
+            });
+
+            this.buildings.set(building.modelId, internalBuilding);
+        });
+
+        // Оставляем только существующее значение из переданных modelId
+        activeModelId =
+            activeModelId !== undefined &&
+            (this.buildings.has(activeModelId) || this.floors.has(activeModelId))
+                ? activeModelId
+                : undefined;
+
+        const modelsToLoad: Map<Id, ModelOptions> = new Map();
+        const buildingVisibility: Map<Id, ModelOptions> = new Map();
+
+        this.buildings.forEach((options, id) => {
+            const modelOptions = getBuildingModelOptions(options);
+            modelsToLoad.set(id, modelOptions);
+            buildingVisibility.set(id, modelOptions);
+        });
+
+        if (activeModelId) {
+            const floorOptions = this.floors.get(activeModelId);
+            if (floorOptions) {
+                if (this.undergroundFloors.has(activeModelId)) {
+                    buildingVisibility.clear(); // показываем только подземный этаж
+                }
+
+                const modelOptions = getFloorModelOptions(floorOptions);
+                buildingVisibility.set(floorOptions.buildingOptions.modelId, modelOptions);
+                modelsToLoad.set(activeModelId, modelOptions);
+            }
+        }
+
+        if (this.options.modelsLoadStrategy === 'waitAll') {
+            this.floors.forEach((options, id) =>
+                modelsToLoad.set(id, getFloorModelOptions(options)),
+            );
+        }
+
+        return this.plugin
+            .addModels(Array.from(modelsToLoad.values()), Array.from(buildingVisibility.keys()))
+            .then(() => {
+                this.setState({
+                    activeModelId,
+                    buildingVisibility,
+                });
+
+                this.plugin.on('click', this.onSceneClick);
+                this.plugin.on('mouseover', this.onSceneMouseOver);
+                this.plugin.on('mouseout', this.onSceneMouseOut);
+                // this.control.on('floorchange', this.floorChangeHandler);
+            });
+    }
+
+    public resetGroundCoveringColor() {
+        const attrs = this.groundCoveringSource.getAttributes();
+        if ('color' in attrs) {
+            this.groundCoveringSource.setAttributes({
+                ...attrs,
+                color: this.options.groundCoveringColor,
+            });
+        }
+    }
+
+    // public isUndergroundFloorShown() {
+    //     return (
+    //         this.state.activeModelId !== undefined &&
+    //         this.undergroundFloors.has(this.state.activeModelId)
+    //     );
+    // }
+
+    public destroy() {
+        this.plugin.off('click', this.onSceneClick);
+        this.plugin.off('mouseover', this.onSceneMouseOver);
+        this.plugin.off('mouseout', this.onSceneMouseOut);
+        // this.control.off('floorChange', this.floorChangeHandler);
+
+        this.plugin.removeModels([...this.buildings.keys(), ...this.floors.keys()]);
+
+        // this.clearPoiGroups();
+
+        this.groundCoveringSource.destroy();
+        this.undergroundFloors.clear();
+
+        this.control.destroy();
+
+        this.popup?.destroy();
+        this.popup = undefined;
+
+        this.state.activeModelId = undefined;
+        this.state.buildingVisibility.clear();
+        this.buildings.clear();
+        this.floors.clear();
+    }
+
+    private setMapOptions(options?: MapOptions) {
+        if (!options) {
+            return;
+        }
+
+        const animationOptions: AnimationOptions = {
+            easing: 'easeInSine',
+            duration: 500,
+        };
+
+        if (options.center) {
+            this.map.setCenter(options.center, animationOptions);
+        }
+        if (options.pitch) {
+            this.map.setPitch(options.pitch, animationOptions);
+        }
+        if (options.rotation) {
+            this.map.setRotation(options.rotation, animationOptions);
+        }
+        if (options.zoom) {
+            this.map.setZoom(options.zoom, animationOptions);
+        }
+    }
+
+    private onSceneMouseOut = (ev: GltfPluginPoiEvent | GltfPluginModelEvent) => {
+        if (ev.target.type === 'poi') {
+            return;
+        }
+
+        this.popup?.destroy();
+    };
+
+    private onSceneMouseOver = ({ target }: GltfPluginPoiEvent | GltfPluginModelEvent) => {
+        if (target.type === 'poi' || target.modelId === undefined) {
+            return;
+        }
+
+        const options = this.buildings.get(target.modelId);
+        if (!options || !options.popupOptions) {
+            return;
+        }
+
+        this.popup = new mapgl.HtmlMarker(this.map, {
+            coordinates: options.popupOptions.coordinates,
+            html: getPopupHtml(options.popupOptions),
+            interactive: false,
+        });
+    };
+
+    private onSceneClick = ({ target }: GltfPluginPoiEvent | GltfPluginModelEvent) => {
+        if (target.type === 'model') {
+            const options = this.buildings.get(target.modelId);
+            if (options) {
+                this.buildingClickHandler(target.modelId);
+            }
+        } else if (target.type === 'poi') {
+            const userData = target.data.userData;
+            if (isObject(userData) && typeof userData.url === 'string') {
+                const a = document.createElement('a');
+                a.setAttribute('href', userData.url);
+                a.setAttribute('target', '_blank');
+                a.click();
+            }
+        }
+    };
+
+    // private floorChangeHandler = (ev: FloorChangeEvent) => {
+    //     const model = this.activeBuilding;
+    //     if (model !== undefined && model.floors !== undefined) {
+    //         if (this.popup !== null) {
+    //             this.popup.destroy();
+    //         }
+
+    //         // click to the building button
+    //         if (ev.floorId === undefined) {
+    //             if (this.prevHoveredModelId !== null) {
+    //                 this.toggleHighlightModel(this.prevHoveredModelId);
+    //             }
+
+    //             this.clearPoiGroups();
+    //             const modelsToAdd: ModelOptions[] = this.isUndergroundFloorShown()
+    //                 ? (this.scene ?? []).map((scenePart) => getBuildingModelOptions(scenePart))
+    //                 : [getBuildingModelOptions(model)];
+
+    //             this.plugin.addModels(modelsToAdd).then(() => {
+    //                 if (this.activeModelId !== undefined) {
+    //                     this.plugin.removeModel(this.activeModelId, true);
+    //                     if (this.isUndergroundFloorShown()) {
+    //                         this.switchOffGroundCovering();
+    //                     }
+    //                 }
+    //                 this.setMapOptions(model?.mapOptions);
+    //                 this.activeModelId = model.modelId;
+    //             });
+    //         }
+    //         // click to the floor button
+    //         if (ev.floorId !== undefined) {
+    //             const selectedFloor = model.floors.find((floor) => floor.id === ev.floorId);
+    //             if (selectedFloor !== undefined && this.activeModelId !== undefined) {
+    //                 const selectedFloorModelOption = getFloorModelOptions(selectedFloor, model);
+
+    //                 // In case of underground -> underground and ground -> ground transitions just switch floor's plan
+    //                 if (this.isUndergroundFloorShown() === Boolean(selectedFloor.isUnderground)) {
+    //                     this.plugin.addModel(selectedFloorModelOption).then(() => {
+    //                         if (this.activeModelId !== undefined) {
+    //                             this.plugin.removeModel(this.activeModelId, true);
+    //                         }
+    //                         this.addFloorPoi(selectedFloor);
+    //                     });
+
+    //                     return;
+    //                 }
+
+    //                 const modelsToAdd: ModelOptions[] = this.isUndergroundFloorShown()
+    //                     ? (this.scene ?? [])
+    //                           .filter((scenePart) => scenePart.modelId !== model.modelId)
+    //                           .map((scenePart) => getBuildingModelOptions(scenePart))
+    //                     : [];
+
+    //                 modelsToAdd.push(selectedFloorModelOption);
+
+    //                 const modelsToRemove = this.isUndergroundFloorShown()
+    //                     ? []
+    //                     : (this.scene ?? [])
+    //                           .filter((scenePart) => scenePart.modelId !== model.modelId)
+    //                           .map((scenePart) => scenePart.modelId);
+
+    //                 modelsToRemove.push(this.activeModelId);
+
+    //                 this.plugin.addModels(modelsToAdd).then(() => {
+    //                     this.plugin.removeModels(modelsToRemove, true);
+    //                     this.isUndergroundFloorShown()
+    //                         ? this.switchOffGroundCovering()
+    //                         : this.switchOnGroundCovering();
+    //                     this.addFloorPoi(selectedFloor);
+    //                 });
+    //             }
+    //         }
+    //     }
+    // };
+
+    private buildingClickHandler = (modelId: Id) => {
+        const buildingOptions = this.buildings.get(modelId);
+        if (!buildingOptions) {
+            return;
+        }
+
+        let activeModelId = modelId;
+        const buildingVisibility: Map<Id, ModelOptions> = new Map();
+        this.buildings.forEach((options, id) => {
+            buildingVisibility.set(id, getBuildingModelOptions(options));
+        });
+
+        // показываем самый высокий этаж здания после клика
+        const floors = buildingOptions.floors ?? [];
+        if (floors.length) {
+            const { modelId: floorModelId, buildingModelId } = floors[floors.length - 1];
+            const floorOptions = this.floors.get(floorModelId);
+            if (floorOptions) {
+                activeModelId = floorModelId;
+                if (this.undergroundFloors.has(floorModelId)) {
+                    buildingVisibility.clear();
+                }
+                buildingVisibility.set(buildingModelId, getFloorModelOptions(floorOptions));
+            }
+        }
+
+        this.setState({
+            buildingVisibility,
+            activeModelId,
+        });
+    };
+
+    // private addFloorPoi(floorOptions?: BuildingFloorOptions) {
+    //     if (floorOptions === undefined) {
+    //         return;
+    //     }
+
+    //     this.activeModelId = floorOptions.id;
+
+    //     this.setMapOptions(floorOptions?.mapOptions);
+
+    //     this.clearPoiGroups();
+
+    //     floorOptions.poiGroups?.forEach((poiGroup) => {
+    //         if (this.activeBuilding?.modelId) {
+    //             this.plugin.addPoiGroup(poiGroup, {
+    //                 modelId: this.activeBuilding?.modelId,
+    //                 floorId: floorOptions.id,
+    //             });
+    //             this.activePoiGroupIds.push(poiGroup.id);
+    //         }
+    //     });
+    // }
+
+    // private clearPoiGroups() {
+    //     this.activePoiGroupIds.forEach((id) => {
+    //         this.plugin.removePoiGroup(id);
+    //     });
+
+    //     this.activePoiGroupIds = [];
+    // }
+
+    // /**
+    //  * Add the group of poi to the map
+    //  *
+    //  * @param options Options of the group of poi to add to the map
+    //  * @param state State of the active building to connect with added the group of poi
+    //  */
+    // public async addPoiGroup(options: PoiGroupOptions, state?: BuildingState) {
+    //     this.poiGroups.add(options, state);
+    // }
+
+    // /**
+    //  * Remove the group of poi from the map
+    //  *
+    //  * @param id Identifier of the group of poi to remove
+    //  */
+    // public removePoiGroup(id: Id) {
+    //     this.poiGroups.remove(id);
+    // }
+
+    private switchOffGroundCovering() {
+        const attrs = { ...this.groundCoveringSource.getAttributes() };
+        delete attrs['color'];
+        this.groundCoveringSource.setAttributes(attrs);
+    }
+
+    private switchOnGroundCovering() {
+        this.groundCoveringSource.setAttributes({
+            ...this.groundCoveringSource.getAttributes(),
+            color: this.options.groundCoveringColor,
+        });
+    }
+}
+
+function getBuildingModelOptions(building: BuildingOptionsInternal): ModelOptions {
+    return {
+        modelId: building.modelId,
+        coordinates: building.coordinates,
+        modelUrl: building.modelUrl,
+        rotateX: building.rotateX,
+        rotateY: building.rotateY,
+        rotateZ: building.rotateZ,
+        offsetX: building.offsetX,
+        offsetY: building.offsetY,
+        offsetZ: building.offsetZ,
+        scale: building.scale,
+        linkedIds: building.linkedIds,
+        interactive: building.interactive,
+    };
+}
+
+function getFloorModelOptions({
+    buildingOptions,
+    id,
+    modelUrl,
+}: BuildingFloorOptionsInternal): ModelOptions {
+    return {
+        modelId: getFloorModelId(buildingOptions.modelId, id),
+        coordinates: buildingOptions.coordinates,
+        modelUrl,
+        rotateX: buildingOptions.rotateX,
+        rotateY: buildingOptions.rotateY,
+        rotateZ: buildingOptions.rotateZ,
+        offsetX: buildingOptions.offsetX,
+        offsetY: buildingOptions.offsetY,
+        offsetZ: buildingOptions.offsetZ,
+        scale: buildingOptions.scale,
+        linkedIds: buildingOptions.linkedIds,
+        interactive: buildingOptions.interactive,
+    };
+}
+
+function getFloorModelId(buildingModelId: string, floorId: string) {
+    return `${buildingModelId}_${floorId}`;
+}
+
+const getPopupHtml = ({ description, title }: PopupOptions) =>
+    `<div class="${classes.popup}">
+        <h2>${title}</h2>
+        ${description ? `<p>${description}</p>` : ''}
+    </div>`;
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -29,7 +29,7 @@ export interface ModelTarget {
     data: ModelOptions;
 
     /**
-     * Identifier of the building's model
+     * Identifier of the building's or floor's model
      */
     modelId: Id;
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -31,12 +31,7 @@ export interface ModelTarget {
     /**
      * Identifier of the building's model
      */
-    modelId?: Id;
-
-    /**
-     * Identifier of the current floor
-     */
-    floorId?: Id;
+    modelId: Id;
 }
 
 export interface PoiTarget {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,4 +1,4 @@
-export type Id = string | number;
+export type Id = string;
 
 export type ColorModelString = `${'rgb' | 'hsl'}(${string})`;
 export type HexColorString = `#${string}`;
@@ -101,21 +101,6 @@ export interface PluginOptions {
      * Color for the ground covering when an underground floor's plan is shown.
      */
     groundCoveringColor?: string;
-}
-
-/**
- * State for the building's scene
- */
-export interface BuildingState {
-    /**
-     * Identifier of the building's model
-     */
-    modelId: Id;
-
-    /**
-     * Identifier of the floor's model
-     */
-    floorId?: Id;
 }
 
 /**

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -104,6 +104,21 @@ export interface PluginOptions {
 }
 
 /**
+ * State for the building's scene
+ */
+export interface BuildingState {
+    /**
+     * Identifier of the building's model
+     */
+    buildingId: string;
+
+    /**
+     * Identifier of the floor's model
+     */
+    floorId?: string;
+}
+
+/**
  * Options for a model
  */
 export interface ModelOptions {

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -4,17 +4,6 @@ export function clamp(value: number, min: number, max: number): number {
     return value;
 }
 
-export function clone<T>(obj: T): T {
-    return JSON.parse(JSON.stringify(obj));
-}
-
-export function createCompoundId(modelId: string | number, floorId?: string | number) {
-    if (floorId === undefined) {
-        return String(modelId);
-    }
-    return `${modelId}_${floorId}`;
-}
-
 export type RequiredExcept<T, K extends keyof T> = T & Required<Omit<T, K>>;
 
 type RequiredOptional<T extends object> = Exclude<

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,16 @@
+import { MapPointerEvent } from '@2gis/mapgl/types';
+import { GltfPluginModelEvent, Id, ModelOptions, ModelTarget } from '../types';
+
+export const createModelEventData = (
+    ev: MapPointerEvent,
+    data: ModelOptions,
+): GltfPluginModelEvent => ({
+    originalEvent: ev.originalEvent,
+    point: ev.point,
+    lngLat: ev.lngLat,
+    target: {
+        type: 'model',
+        modelId: data.modelId,
+        data,
+    },
+});


### PR DESCRIPTION
Доработки будут тут: https://jira.2gis.ru/browse/TILES-5918
Что сделал в этом МР:
- в ф-ии `init` разложил конфиг сцены в удобный для использования внутри формат
- сделал стейт, который отвечает за показ, загрузку моделей, включение подложки и изменение контрола этажей
- порефакторил обработчики

Почему стейт в RealtyScene?
Хочется оставить плагин максимально простым, т.к. использование RealtyScene - частный случай.
RealtyScene - достаточно сложная штука и стейт там оправдан.

Как формируется buildingVisibility в стейте?
Это мапа id-шников зданий (боксов) на опции либо этого здания, либо его этажа. Т.е. если показываются только коробки, то везде будут опции зданий; если показан этаж, то опции здания будут заменены на этажные; если этаж подземный, то везде будет undefined, кроме здания, у которого показывается этот этаж. 