### PR TITLE
Some fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2gis/mapgl-gltf",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@2gis/mapgl-gltf",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "@2gis/mapgl": "^1.47.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2gis/mapgl-gltf",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Plugin for the rendering glTF models with MapGL",
   "main": "dist/bundle.js",
   "typings": "dist/types/index.d.ts",

--- a/src/labelGroups.ts
+++ b/src/labelGroups.ts
@@ -15,6 +15,10 @@ export const DEFAULT_IMAGE: LabelImage = {
     padding: [5, 10, 5, 10],
 };
 
+/**
+ * @hidden
+ * @internal
+ */
 export class LabelGroups {
     private labelsByGroupId: Map<string, Label[]> = new Map();
 

--- a/src/realtyScene/realtyScene.ts
+++ b/src/realtyScene/realtyScene.ts
@@ -103,12 +103,23 @@ export class RealtyScene {
             const prevModelOptions = prevState.buildingVisibility.get(buildingId);
             const newModelOptions = newState.buildingVisibility.get(buildingId);
 
-            // если опции не изменились, то ничего не делаем
+            // если опции не изменились, то выставляем только опции карты, если модель активна
             if (
                 prevModelOptions?.modelId === newModelOptions?.modelId &&
                 prevState.status === newState.status
             ) {
                 buildingVisibility.set(buildingId, prevModelOptions);
+
+                if (prevModelOptions && prevModelOptions.modelId === newState.activeModelId) {
+                    const options =
+                        this.buildings.get(prevModelOptions.modelId) ??
+                        this.floors.get(prevModelOptions.modelId);
+
+                    if (options) {
+                        this.setMapOptions(options.mapOptions);
+                    }
+                }
+
                 return;
             }
 
@@ -230,14 +241,16 @@ export class RealtyScene {
                     this.control.show({
                         buildingModelId: buildingOptions.modelId,
                         activeModelId: newState.activeModelId,
-                        floorLevels: [
-                            {
-                                modelId: buildingOptions.modelId,
-                                icon: 'building',
-                                text: '',
-                            },
-                            ...buildingOptions.floors,
-                        ],
+                        floorLevels: buildingOptions.floors.length
+                            ? [
+                                  {
+                                      modelId: buildingOptions.modelId,
+                                      icon: 'building',
+                                      text: '',
+                                  },
+                                  ...buildingOptions.floors,
+                              ]
+                            : [],
                     });
                 }
             }


### PR DESCRIPTION
- убрал из паблика тип `LabelGroups` + из референса тоже. Пользователь напрямую с ним не работает, а юзает методы `addLabelGroup` и `removeLabelGroup`;
- сделал так, чтобы не показывался контрол, если у здания нет этажей. Неправильную работу можно посмотреть [тут](https://docs-tiles-6197-gltf-plugin2.web-staging.2gis.ru/en/mapgl/immersive/gltf2-plugin#nav-lvl2--%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80_%D0%B4%D0%BE%D0%B1%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D1%8F_%D0%B8%D0%BD%D1%82%D0%B5%D1%80%D0%B0%D0%BA%D1%82%D0%B8%D0%B2%D0%BD%D0%BE%D0%B9_%D1%81%D1%86%D0%B5%D0%BD%D1%8B_%D0%BD%D0%B5%D0%B4%D0%B2%D0%B8%D0%B6%D0%B8%D0%BC%D0%BE%D1%81%D1%82%D0%B8_%D0%BD%D0%B0_%D0%BA%D0%B0%D1%80%D1%82%D1%83).
- пофиксил применение mapOptions для моделей, которые не имеют этажей, при клике в них.