### PR TITLE
Added color texture index option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
             - uses: actions/checkout@v3
             - name: Build container and run tests
               run: docker compose up --build --exit-code-from test test
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               if: ${{ failure() }}
               with:
                   path: test/screenshots/__screenshots__/**/__diff_output__/*.png

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@2gis/mapgl-gltf",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@2gis/mapgl-gltf",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "BSD-2-Clause",
       "devDependencies": {
         "@2gis/mapgl": "^1.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@2gis/mapgl-gltf",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Plugin for the rendering glTF models with MapGL",
   "main": "dist/bundle.js",
   "typings": "dist/types/index.d.ts",

--- a/src/defaultOptions.ts
+++ b/src/defaultOptions.ts
@@ -8,6 +8,7 @@ export const defaultOptions: Required<PluginOptions> = {
     modelsBaseUrl: '',
     modelsLoadStrategy: 'waitAll',
     modelsNearCameraFade: 2500,
+    modelsColorTextureUvIndex: 0,
     labelGroupDefaults: {
         fontSize: DEFAULT_FONT_SIZE,
         fontColor: DEFAULT_FONT_COLOR,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -159,6 +159,7 @@ export class GltfPlugin extends Evented<GltfPluginEventTable> {
                     minZoom: options.minZoom ?? this.options.minZoom,
                     maxZoom: options.maxZoom ?? this.options.maxZoom,
                     nearCameraFade: this.options.modelsNearCameraFade,
+                    colorTextureUvIndex: this.options.modelsColorTextureUvIndex,
                 });
 
                 const model: Model = {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -99,6 +99,12 @@ export interface PluginOptions {
      * It's set in units along Z axis of the WebGL space.
      */
     modelsNearCameraFade?: number;
+    /**
+     * Index of the color texture to be used for all models.
+     * @hidden
+     * @internal
+     */
+    modelsColorTextureUvIndex?: number;
 }
 
 /**


### PR DESCRIPTION
- добавил скрытую опцию `modelsColorTextureUvIndex`, чтобы можно было включать темную тему в моделях
- поднял actions/upload-artifact до 4й версии, т.к. 3я теперь deprecated
- обсудить: в `tsconfig` отсутствует опция `stripInternal`, а значит теги `@internal` в комментах не обрабатываются, и скрытые типы просачиваются в `.d.ts` файлы. Это не эпик, но фейл.

Как посмотреть (только локально):
1. Положить модель `SakuraPark_day_night_1.glb` из ассетов jakarta в папку demo/models
2. В demo/index.ts в опциях плагина задать `modelsBaseUrl` -> `/models/` и добавить `modelsColorTextureUvIndex: 1`
3. Запустить демку.
4. Добавить модель на карту (появится модель Сакуры для ночной темы.):
```
gltfPlugin.addModel({
        modelId: '03a234cb',
        coordinates: [47.245286302641034, 56.134743473834099],
        modelUrl: 'SakuraPark_day_night_1.glb',
        linkedIds: ['70030076555823021'],
        interactive: true,
});
```
   
5. Если поменять `modelsColorTextureUvIndex` -> `0`, то будет дневная текстура у модели. 