### PR TITLE
Использование функции isIdle() для определения готовности карты

### DIFF
--- a/test/puppeteer/utils.ts
+++ b/test/puppeteer/utils.ts
@@ -95,5 +95,5 @@ export async function makeSnapshot(
 }
 
 export async function waitForReadiness(page: PuppeteerPage) {
-    await page.waitForFunction(() => window.map.isReady());
+    await page.waitForFunction(() => window.map.isIdle());
 }

--- a/test/puppeteer/utils.ts
+++ b/test/puppeteer/utils.ts
@@ -46,10 +46,6 @@ export function makeScreenshotsPath(relativePath: string) {
 export async function initMapWithOptions(page: PuppeteerPage, options?: Partial<mapgl.MapOptions>) {
     await page.evaluate((opts) => {
         window.map = new mapgl.Map('map', opts ?? {});
-        window.map.on('idle', () => {
-            window.ready = true;
-        });
-        window.ready = false;
     }, options as any);
 }
 
@@ -99,6 +95,5 @@ export async function makeSnapshot(
 }
 
 export async function waitForReadiness(page: PuppeteerPage) {
-    await page.waitForFunction(() => window.ready);
-    await page.evaluate(() => (window.ready = false));
+    await page.waitForFunction(() => window.map.isIdle());
 }

--- a/test/puppeteer/utils.ts
+++ b/test/puppeteer/utils.ts
@@ -95,5 +95,5 @@ export async function makeSnapshot(
 }
 
 export async function waitForReadiness(page: PuppeteerPage) {
-    await page.waitForFunction(() => window.map.isIdle());
+    await page.waitForFunction(() => window.map.isReady());
 }

--- a/test/screenshots/plugin.screen.ts
+++ b/test/screenshots/plugin.screen.ts
@@ -226,6 +226,7 @@ describe('GltfPlugin', () => {
                 await page.evaluate(() => {
                     window.map.setStyleZoom(16.2, { animate: false });
                 });
+                await new Promise(resolve => setTimeout(resolve, 100));
                 await waitForReadiness(page);
                 await makeSnapshot(page, dirPath, 'plugin_options_minZoom_maxZoom_visible_cube');
             });

--- a/test/screenshots/plugin.screen.ts
+++ b/test/screenshots/plugin.screen.ts
@@ -224,9 +224,8 @@ describe('GltfPlugin', () => {
 
             it('cube is only visible', async () => {
                 await page.evaluate(() => {
-                    window.map.setStyleZoom(16.2, { animate: false });
+                    window.map.setStyleZoom(16.2);
                 });
-                await new Promise(resolve => setTimeout(resolve, 100));
                 await waitForReadiness(page);
                 await makeSnapshot(page, dirPath, 'plugin_options_minZoom_maxZoom_visible_cube');
             });


### PR DESCRIPTION
Заиспользовал в тестах функцию `isIdle()` вместо события `idle`, чтобы более надежно определять спокойной состояние карты. 

Использование события `idle` создает возможность гонок, что по-видимому и случается в случае, когда этот плагин тестирутся с веткой рефакторинга инстансов. 